### PR TITLE
Generate class for core; AOT it for jar/uberjar.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,6 @@
                                                     com.sun.jmdk/jmxtools
                                                     com.sun.jmx/jmxri]]]
 
-  :main ^:skip-aot b.core
+  :main b.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/src/b/core.clj
+++ b/src/b/core.clj
@@ -1,4 +1,5 @@
 (ns b.core
+  (:gen-class)
   (:require [b.p2p :as p2p]
             [b.block :as block]
             [b.chain :as chain]


### PR DESCRIPTION
Lein gave warning that no class for defined entry point NS was defined.